### PR TITLE
style(farm): refine PoolCard design

### DIFF
--- a/packages/ui/src/components/Header/index.tsx
+++ b/packages/ui/src/components/Header/index.tsx
@@ -485,7 +485,7 @@ export default function Header() {
                 <Text>{t('Liquidity')}</Text>
               </FixedWidthStyledNavLink>
               <FixedWidthStyledNavLink id={`earn-nav-link`} to={'/farm'}>
-                <Text>{t('Earn')}</Text>
+                <Text>{t('Farm')}</Text>
               </FixedWidthStyledNavLink>
               {/* <StyledNavLink id={`stake-nav-link`} to={'/uni'}>
             UNI

--- a/packages/ui/src/pages/Farm/PoolCard.tsx
+++ b/packages/ui/src/pages/Farm/PoolCard.tsx
@@ -121,7 +121,7 @@ const StakingColumn = styled.div<{ isMobile: boolean; isHideInMobile?: boolean; 
     margin-bottom: 0.46rem;
   }
   .actions {
-    margin-left: 0.8rem;
+    margin-left: auto;
 
     svg.button {
       cursor: pointer;
@@ -280,10 +280,20 @@ export default function PoolCard({ pid, stakingInfo }: { pid: number; stakingInf
     isHideInMobile?: boolean
     marginTop?: string | number
   }) => {
+    const parsedPendingAmount = `${stakingInfo.pendingReward.toSignificant(6)} ${rewardToken.symbol}`
     return (
       <StakingColumn isMobile={isMobile} isHideInMobile={isHideInMobile} style={{ marginTop }}>
         <StakingColumnTitle>Earned Rewards</StakingColumnTitle>
-        <TYPE.white fontSize="1.2rem">
+        <TYPE.white
+          title={parsedPendingAmount}
+          fontSize="1.2rem"
+          style={{
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            maxWidth: isMobile ? '50%' : '70%'
+          }}
+        >
           {stakingInfo.pendingReward.toSignificant(6)} {rewardToken.symbol}
         </TYPE.white>
         <div className="actions">
@@ -292,7 +302,7 @@ export default function PoolCard({ pid, stakingInfo }: { pid: number; stakingInf
             width="auto"
             fontSize="0.9rem"
             padding="0.166rem 0.4rem"
-            borderRadius="0.133rem"
+            borderRadius="0.6rem"
             onClick={() => setShowClaimRewardModal(true)}
           >
             Claim
@@ -306,7 +316,7 @@ export default function PoolCard({ pid, stakingInfo }: { pid: number; stakingInf
     <Wrapper showBackground={isStaking} bgColor={backgroundColor}>
       <TopSection>
         <DoubleCurrencyLogo currency0={currency0} currency1={currency1} size={24} />
-        <TYPE.white fontWeight={600} fontSize={18} style={{ marginLeft: '0.26rem' }}>
+        <TYPE.white fontWeight={600} fontSize={18} style={{ marginLeft: '0.26rem' }} width="12rem">
           {poolInfo?.stakingAsset.name}
         </TYPE.white>
         {poolInfo?.stakingAsset.isLpToken && (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3261732/195559916-0bdd2840-5a35-48b6-a89a-78ca47749216.png)
- Add Bigger Radius and auto left margin to Claim Button
- align the LP link and Claim Button altogether
- [renaming Earn tab to Farm](https://github.com/teleport-network/interface/pull/90/commits/d079d00a9f0c06776a4088ab45d76ad63a19267d)